### PR TITLE
Fix instagram service self api endpoint to use v1

### DIFF
--- a/includes/services/extended/instagram.php
+++ b/includes/services/extended/instagram.php
@@ -20,7 +20,7 @@ class Keyring_Service_Instagram extends Keyring_Service_OAuth2 {
 
 		$this->set_endpoint( 'authorize',    'https://api.instagram.com/oauth/authorize/',   'GET'  );
 		$this->set_endpoint( 'access_token', 'https://api.instagram.com/oauth/access_token', 'POST' );
-		$this->set_endpoint( 'self',         'https://api.instagram.com/v2/users/self',      'GET'  );
+		$this->set_endpoint( 'self',         'https://api.instagram.com/v1/users/self',      'GET'  );
 
 		$creds = $this->get_credentials();
 		$this->app_id  = $creds['app_id'];


### PR DESCRIPTION
While testing connection it would say that it doesn't work. Looking further into it, I've noticed that [instagram API endpoints page](https://www.instagram.com/developer/endpoints/) refers to `v1` instead of `v2`.

I've changed and tested the connection and it worked. Perhaps, it was a mistype?
